### PR TITLE
Added support for custom commands in macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,61 @@ macro.
 6. You've now created a macro. Use it by setting the chosen profile and pressing
 the chosen macro key.
 
+## Advanced macros
+
+You can manually edit a macro by editing its associated XML file, located in
+Sidewinderd's working directory. If you have not set one in the config, it will be
+located at `/home_dir_of_user/.local/share/sidewinderd`, where `home_dir_of_user` is the
+home directory of the user you have set in Sidewinderd's config. By default, this user
+is `root`, but it is recommended to change this. The macro files are then located at `profile_#/s#.xml` where `profile_#` is the profile/bank number (e.g. if your keyboard has M1-3 keys, then the M1 set of macros would be located under `profile_1`) and `s#.xml` is the macro number (e.g. if your keyboard has macro keys G1-6 then the macro for G1 would be located at `s1.xml`).
+
+Macro XML files consist of a document root `<Macro>`, the contents of which are a list of 
+elements, representing actions for Sidewinderd to execute when the key is pressed.
+Sidewinderd currently supports the following actions:
+1. `<KeyBoardEvent Down="1|0">key</KeyBoardEvent>` - emits a virtual keyboard event, where the value of attribute `Down` is either 1 for a key press event or 0 for a key release event and `key` is the [key code](https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h) of the desired key
+2. `<DelayEvent>msec</DelayEvent>` - Delays for a time, where `msec` is the number of milliseconds to delay
+3. `<RunCommand>command</RunCommand>` - Runs a command in the shell, where `command` is the command to run. Supports `sudo` if Sidewinderd was originally run with `sudo`.
+
+### Examples
+This macro will type the letters "asdf" with the same delay between keypresses as when they were typed during recording.
+```
+<Macro>
+    <KeyBoardEvent Down="1">30</KeyBoardEvent>
+    <DelayEvent>112</DelayEvent>
+    <KeyBoardEvent Down="1">31</KeyBoardEvent>
+    <DelayEvent>39</DelayEvent>
+    <KeyBoardEvent Down="0">30</KeyBoardEvent>
+    <DelayEvent>31</DelayEvent>
+    <KeyBoardEvent Down="1">32</KeyBoardEvent>
+    <DelayEvent>80</DelayEvent>
+    <KeyBoardEvent Down="0">31</KeyBoardEvent>
+    <DelayEvent>7</DelayEvent>
+    <KeyBoardEvent Down="1">33</KeyBoardEvent>
+    <DelayEvent>40</DelayEvent>
+    <KeyBoardEvent Down="0">32</KeyBoardEvent>
+    <DelayEvent>39</DelayEvent>
+    <KeyBoardEvent Down="0">33</KeyBoardEvent>
+</Macro>
+```
+This macro will type the letters "asdf" instantly, with no delay between keypresses.
+```
+<Macro>
+    <KeyBoardEvent Down="1">30</KeyBoardEvent>
+    <KeyBoardEvent Down="1">31</KeyBoardEvent>
+    <KeyBoardEvent Down="0">30</KeyBoardEvent>
+    <KeyBoardEvent Down="1">32</KeyBoardEvent>
+    <KeyBoardEvent Down="0">31</KeyBoardEvent>
+    <KeyBoardEvent Down="1">33</KeyBoardEvent>
+    <KeyBoardEvent Down="0">32</KeyBoardEvent>
+    <KeyBoardEvent Down="0">33</KeyBoardEvent>
+</Macro>
+```
+This macro will run the command `xscreensaver-command --lock`, to lock the screen on systems running [xscreensaver](https://www.jwz.org/xscreensaver/).
+```
+<Macro>
+    <RunCommand>xscreensaver-command --lock</RunCommand>
+</Macro>
+```
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -100,8 +100,10 @@ Macro XML files consist of a document root `<Macro>`, the contents of which are 
 elements, representing actions for Sidewinderd to execute when the key is pressed.
 Sidewinderd currently supports the following actions:
 1. `<KeyBoardEvent Down="1|0">key</KeyBoardEvent>` - emits a virtual keyboard event, where the value of attribute `Down` is either 1 for a key press event or 0 for a key release event and `key` is the [key code](https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h) of the desired key
-2. `<DelayEvent>msec</DelayEvent>` - Delays for a time, where `msec` is the number of milliseconds to delay
-3. `<RunCommand>command</RunCommand>` - Runs a command in the shell, where `command` is the command to run. Supports `sudo` if Sidewinderd was originally run with `sudo`.
+2. `<MouseEvent Direction="X|Y">pixels</MouseEvent>` - Moves the mouse in X or Y axis for the number of pixels required, which can be a negative value.
+3. `<MouseEvent Click="Right|Left"></MouseEvent>` - Sends a mouse click on the Right or Left mouse button
+4. `<DelayEvent>msec</DelayEvent>` - Delays for a time, where `msec` is the number of milliseconds to delay
+5. `<RunCommand>command</RunCommand>` - Runs a command in the shell, where `command` is the command to run. Supports `sudo` if Sidewinderd was originally run with `sudo`.
 
 ### Examples
 This macro will type the letters "asdf" with the same delay between keypresses as when they were typed during recording.
@@ -143,6 +145,13 @@ This macro will run the command `xscreensaver-command --lock`, to lock the scree
     <RunCommand>xscreensaver-command --lock</RunCommand>
 </Macro>
 ```
+This macro will move the mouse 20 pixels to the left, 30 pixels up then do a right click.
+```
+<MouseEvent Direction="X">20</MouseEvent>
+<MouseEvent Direction="Y">-30</MouseEvent>
+<MouseEvent Click="Right"></MouseEvent>
+```
+
 
 ## Contribution
 

--- a/src/core/keyboard.cpp
+++ b/src/core/keyboard.cpp
@@ -83,6 +83,30 @@ void Keyboard::playMacro(std::string macroPath, VirtualInput *virtInput) {
 				request.tv_nsec = 1000000L * delay;
 				nanosleep(&request, &remain);
 			}
+			else if (child->Name() == std::string("MouseEvent")) {
+				int type = EV_REL;
+				int stype = REL_X;
+				int value = 0;
+				if (child->GetText() != NULL) {
+					value = std::atoi(child->GetText());
+				}
+
+				if (child->Attribute("Direction") != NULL && child->Attribute("Direction") == std::string("Y")){
+					stype = REL_Y;
+				}
+				if (child->Attribute("Click") != NULL){
+					type = EV_KEY;
+					stype = BTN_LEFT;
+					if (child->Attribute("Click") == std::string("Right")){
+						stype = BTN_RIGHT;
+					}
+					// Click down then Click up
+					virtInput->sendEvent(type,stype,1);
+					virtInput->sendEvent(type,stype,0);
+				}else{
+					virtInput->sendEvent(type,stype,value);
+				}
+			}
 			else if (child->Name() == std::string("RunCommand")) {
 				std::string command(child->GetText());
 				std::thread thread(runCommand, command);

--- a/src/core/keyboard.hpp
+++ b/src/core/keyboard.hpp
@@ -56,6 +56,9 @@ class Keyboard {
 		struct KeyData pollDevice(nfds_t nfds);
 		virtual void handleKey(struct KeyData *keyData) = 0;
 		void handleRecordMode(Led *ledRecord, const int keyRecord);
+
+	private:
+		static void runCommand(std::string command);
 };
 
 #endif

--- a/src/core/virtual_input.cpp
+++ b/src/core/virtual_input.cpp
@@ -71,6 +71,12 @@ void VirtualInput::createUidev() {
 	process_->unprivilege();
 	/* set all keybits */
 	ioctl(uifd_, UI_SET_EVBIT, EV_KEY);
+	ioctl(uifd_, UI_SET_KEYBIT, BTN_LEFT);
+	ioctl(uifd_, UI_SET_KEYBIT, BTN_RIGHT);
+
+	ioctl(uifd_, UI_SET_EVBIT, EV_REL);
+	ioctl(uifd_, UI_SET_RELBIT, REL_X);
+	ioctl(uifd_, UI_SET_RELBIT, REL_Y);
 
 	for (int i = KEY_ESC; i <= KEY_KPDOT; i++) {
 		ioctl(uifd_, UI_SET_KEYBIT, i);


### PR DESCRIPTION
In addition to `KeyBoardEvent` and `DelayEvent` actions in macros, sidewinderd now supports the `RunCommand` action, which will execute the specified command in the shell. This allows for more power when creating macros, as users can now bind custom commands to macro keys (for example, I have one of my macro keys lock my screen by running `xscreensaver-command --lock` with the `RunCommand` action.

I also wrote a detailed section in README.md on how this works and how the user can manually edit macros to make them more powerful, with examples of what can be done.