### PR TITLE
Add default_delay to config and use it during record if capture_delay is false

### DIFF
--- a/etc/sidewinderd.conf
+++ b/etc/sidewinderd.conf
@@ -7,6 +7,10 @@ user = "root";
 # If set to false, macro recording will not capture any delays.
 capture_delays = true;
 
+# Default delay in milliseconds to insert between keystrokes when capture_delays is false
+# Set to 0 to disable implicit delays
+default_delay = 5;
+
 # Change the PID file path here, if you experience issues with the default path.
 pid-file = "/var/run/sidewinderd.pid";
 


### PR DESCRIPTION
This pull request introduces a configurable default delay between keystrokes when macro recording, improving flexibility for users who do not want to capture real delays. The changes allow users to set a `default_delay` value in the configuration file, and the macro recording logic now inserts this delay when delay capture is disabled.

The need for this commit came about because the default behavior when "capture_delays" is false is to have no delay at all. This tends to be too fast, and keystrokes can get lost.

**Configuration enhancements:**

* Added the `default_delay` option to `etc/sidewinderd.conf`, allowing users to specify a default delay in milliseconds between keystrokes when `capture_delays` is set to false.

**Macro recording logic improvements:**

* Updated `Keyboard::recordMacro` in `src/core/keyboard.cpp` to insert either the captured delay or the configured `default_delay` between keystrokes, depending on the `capture_delays` setting. 